### PR TITLE
protocol_socket: Retry if BlockingIOError occurs in reset_input_buffer.

### DIFF
--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -239,6 +239,9 @@ class Serial(SerialBase):
             ready, _, _ = select.select([self._socket], [], [], 0)
             try:
                 self._socket.recv(4096)
+            except BlockingIOError:
+                # Try again in case of windows WSAEWOULDBLOCK error.
+                pass
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore EAGAIN errors. all other errors are shown


### PR DESCRIPTION
On some windows machines opening a RFC 2217 connection results in an **BlockingIOError: [WinError 10035]**.  As this error is nonfatal and the operation should be retried later according to [Windows Sockets Error Codes](https://msdn.microsoft.com/en-us/library/windows/desktop/ms740668%28v=vs.85%29.aspx) simply ignoring this exception solves the problem.

